### PR TITLE
Bump microsoft/setup-msbuild from 1.0.2 to 1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       run: nuget restore REIMU_Plugins_V2.sln
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Build
       run: >


### PR DESCRIPTION
I don't know why Dependabot can't update it.

    updater | INFO <job_239774818> Checking if microsoft/setup-msbuild 1.0.2 needs updating
      proxy | 2021/12/03 16:01:27 [024] GET https://github.com:443/microsoft/setup-msbuild.git/info/refs?service=git-upload-pack
      proxy | 2021/12/03 16:01:27 [024] * authenticating git server request (host: github.com)
      proxy | 2021/12/03 16:01:27 [024] 200 https://github.com:443/microsoft/setup-msbuild.git/info/refs?service=git-upload-pack
    updater | INFO <job_239774818> Latest version is c26a08ba26249b81327e26f6ef381897b6a8754d
    updater | INFO <job_239774818> No update needed for microsoft/setup-msbuild 1.0.2